### PR TITLE
Fix MODULES-10947: install iptables-persistent on Raspberry Pi OS

### DIFF
--- a/manifests/linux.pp
+++ b/manifests/linux.pp
@@ -69,7 +69,7 @@ class firewall::linux (
         require         => Package['iptables'],
       }
     }
-    'Debian', 'Ubuntu': {
+    'Debian', 'Raspbian', 'Ubuntu': {
       class { "${title}::debian":
         ensure       => $ensure,
         enable       => $enable,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -46,7 +46,7 @@ class firewall::params {
     'Debian': {
       $service_name_v6 = undef
       case $::operatingsystem {
-        'Debian': {
+        'Debian', 'Raspbian': {
           if versioncmp($::operatingsystemrelease, 'unstable') >= 0 {
             $service_name = 'netfilter-persistent'
             $package_name = 'netfilter-persistent'


### PR DESCRIPTION
Raspberry Pi OS was renamed from "Raspbian" and is Debian-based.  This detects Raspbian explicitly.